### PR TITLE
Modify the way we add the new goal to global state

### DIFF
--- a/src/CreateCategoryModal.tsx
+++ b/src/CreateCategoryModal.tsx
@@ -84,10 +84,10 @@ export const CreateCategoryModal = (props: CategoryModalProps) => {
                 JSON.stringify([...globalState.get().goals, newGoal])
               );
 
-              globalState.set((previousGlobalState) => ({
-                ...previousGlobalState,
-                goals: [...previousGlobalState.goals, newGoal],
-              }));
+              globalState.goals.set((previousGoals) => [
+                ...previousGoals,
+                newGoal,
+              ]);
 
               onCloseModal();
             }}

--- a/src/CreateCategoryModal.tsx
+++ b/src/CreateCategoryModal.tsx
@@ -81,7 +81,7 @@ export const CreateCategoryModal = (props: CategoryModalProps) => {
 
               localStorage.setItem(
                 "goals",
-                JSON.stringify([...globalState.get().goals, newGoal])
+                JSON.stringify([...globalState.goals.get(), newGoal])
               );
 
               globalState.goals.set((previousGoals) => [

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -28,10 +28,8 @@ export default function Sidebar() {
   const globalState = useHookstate(store);
 
   React.useEffect(() => {
-    if (globalState.get().goals) {
-      setGoals(globalState.get().goals);
-    }
-  }, [globalState]);
+    setGoals(globalState.goals.get());
+  }, [globalState.goals]);
 
   return (
     <Box minH="100vh" bg={useColorModeValue("gray.100", "gray.900")}>


### PR DESCRIPTION
Was reading the [docs](https://hookstate.js.org/docs/nested-state#updating-existing-property) for `hookstate`, and saw they had a recommended way for updating a single property within a nested state object. So updating to use that way instead 